### PR TITLE
Add arbitrary query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ people = store.from(:people).filter(name: "Alice").all
 #=> [#<Lurch::Resource[Person] id: "2", name: "Alice">]
 ```
 
+## Other query parameters
+
+You can add arbitrary parameters as well. Note that your server should adhere to [JSON:API's query parameter constraints](https://jsonapi.org/format/#query-parameters).
+
+```ruby
+people = store.from(:people).params(someQuery: "blue").all
+# => GET /people?someQuery=blue
+```
+
 ## Relationships
 
 Lurch can fetch *has-many* and *has-one* relationships from the server when they are provided as *related links*:

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
 * [x] Configurable pluralization/singularization (don't assume urls and types are always plural)
 * [x] Handle paginated results
 * [ ] Allow arbitrary headers
-* [ ] Allow arbitrary query params
+* [x] Allow arbitrary query params
 * [ ] Singleton resources
 * [ ] Handle links better?
 * [x] >= 90% test coverage

--- a/lib/lurch/query.rb
+++ b/lib/lurch/query.rb
@@ -7,6 +7,7 @@ module Lurch
       @include = []
       @fields = Hash.new { [] }
       @sort = []
+      @params = {}
       @page = {}
     end
 
@@ -33,6 +34,11 @@ module Lurch
 
     def page(params)
       @page.merge!(params)
+      self
+    end
+
+    def params(params)
+      @params.merge!(params)
       self
     end
 
@@ -91,19 +97,23 @@ module Lurch
 
     def to_query
       QueryBuilder.new(
-        {
+        other_params.merge!(
           filter: filter_query,
           include: include_query,
           fields: fields_query,
           sort: sort_query,
           page: page_query
-        }.merge(other_uri_params)
+        ).merge!(other_uri_params)
       ).encode
     end
 
     def other_uri_params
       # TODO: existing non-standard uri query params from the provided uri (if any)
       {}
+    end
+
+    def other_params
+      @inflector.encode_keys(@params)
     end
 
     def filter_query

--- a/test/lurch/test_queries.rb
+++ b/test/lurch/test_queries.rb
@@ -80,9 +80,23 @@ class TestQueries < Minitest::Test
     assert_requested(stub)
   end
 
+  def test_params
+    stub = stub_get(
+      "#{person_type}?baz[boom]=baum&foo=bar",
+      @response_factory.no_content_response
+    )
+
+    @store
+      .from(:people)
+      .params(foo: 'bar', baz: { boom: 'baum' })
+      .all
+
+    assert_requested(stub)
+  end
+
   def test_all
     stub = stub_get(
-      "#{person_type}?filter[name]=Alice&filter[foo][]=bar&filter[foo][]=baz&include=#{@inflector.encode_key(:phone_numbers)},friends,friends.#{@inflector.encode_key(:phone_numbers)}&fields[#{person_type}]=name&fields[#{phone_number_type}]=name,number&sort=name,-foo,bar&page[number]=12&page[size]=50",
+      "#{person_type}?filter[name]=Alice&filter[foo][]=bar&filter[foo][]=baz&include=#{@inflector.encode_key(:phone_numbers)},friends,friends.#{@inflector.encode_key(:phone_numbers)}&fields[#{person_type}]=name&fields[#{phone_number_type}]=name,number&boom=baum&sort=name,-foo,bar&page[number]=12&page[size]=50",
       @response_factory.no_content_response
     )
 
@@ -92,6 +106,7 @@ class TestQueries < Minitest::Test
       .include(:phone_numbers, :friends, "friends.phone_numbers")
       .fields([:name])
       .fields(:phone_number, [:name, :number])
+      .params(boom: 'baum')
       .sort(:name, {foo: :desc}, {bar: :asc})
       .page(number: 12, size: 50)
 


### PR DESCRIPTION
This add a `#params` method to add arbitrary query params.

We need this, because our API has required query parameters: `start_date?2019-03-02`.