### PR TITLE
Use dry-inflector, because Inflecto is no longer maintained

### DIFF
--- a/lib/lurch.rb
+++ b/lib/lurch.rb
@@ -1,6 +1,5 @@
 require "uri"
 
-require "inflecto"
 require "rack"
 require "faraday"
 require "typhoeus"

--- a/lib/lurch/changeset.rb
+++ b/lib/lurch/changeset.rb
@@ -5,7 +5,7 @@ module Lurch
 
     def initialize(type, attributes = {})
       is_resource = type.is_a?(Resource)
-      @type = is_resource ? type.type : Inflector.decode_type(type)
+      @type = is_resource ? type.type : type
       @id = is_resource ? type.id : nil
       @attributes = attributes
       @relationships = {}

--- a/lib/lurch/changeset.rb
+++ b/lib/lurch/changeset.rb
@@ -26,7 +26,7 @@ module Lurch
       attrs = attrs.concat(attributes.map { |name, value| "#{name}: #{value.inspect}" })
       attrs = attrs.concat(relationships.map { |name, value| "#{name}: #{value.inspect}" })
       inspection = attrs.join(", ")
-      "#<#{self.class}[#{Inflector.classify(type)}] #{inspection}>"
+      "#<#{self.class}[#{type}] #{inspection}>"
     end
   end
 end

--- a/lib/lurch/collection.rb
+++ b/lib/lurch/collection.rb
@@ -74,7 +74,7 @@ module Lurch
     end
 
     def inspect
-      suffix = @resources.first ? "[#{Inflector.classify(@resources.first.type)}]" : ""
+      suffix = @resources.first ? "[#{@resources.first.type}]" : ""
       inspection = size ? ["size: #{size}"] : []
       inspection << ["pages: #{page_count}"] if page_count
       "#<#{self.class}#{suffix} #{inspection.join(', ')}>"

--- a/lib/lurch/inflector.rb
+++ b/lib/lurch/inflector.rb
@@ -1,24 +1,29 @@
+# frozen_string_literal: true
+
+require "dry/inflector"
+
 module Lurch
   class Inflector
     def initialize(inflection_mode, types_mode)
+      @inflector = Dry::Inflector.new
       define_encode_key(inflection_mode)
       define_encode_type(types_mode)
     end
 
     def decode_key(key)
-      Inflecto.underscore(key.to_s).to_sym
+      inflector.underscore(key.to_s).to_sym
     end
 
     def decode_type(type)
-      Inflecto.pluralize(decode_key(type)).to_sym
+      inflector.pluralize(decode_key(type)).to_sym
     end
 
     def define_encode_key(inflection_mode)
       case inflection_mode
       when :dasherize
-        define_singleton_method(:encode_key) { |key| Inflecto.dasherize(key.to_s) }
+        define_singleton_method(:encode_key) { |key| inflector.dasherize(key.to_s) }
       when :underscore
-        define_singleton_method(:encode_key) { |key| Inflecto.underscore(key.to_s) }
+        define_singleton_method(:encode_key) { |key| inflector.underscore(key.to_s) }
       else
         raise ArgumentError, "Invalid inflection mode: #{inflection_mode}"
       end
@@ -29,12 +34,12 @@ module Lurch
       when :pluralize
         define_singleton_method(:encode_type) do |type|
           key = encode_key(type)
-          Inflecto.pluralize(key)
+          inflector.pluralize(key)
         end
       when :singularize
         define_singleton_method(:encode_type) do |type|
           key = encode_key(type)
-          Inflecto.singularize(key)
+          inflector.singularize(key)
         end
       else
         raise ArgumentError, "Invalid types mode: #{types_mode}"
@@ -52,5 +57,9 @@ module Lurch
         acc[encode_type(key)] = block_given? ? yield(value) : value
       end
     end
+
+  private
+
+    attr_reader :inflector
   end
 end

--- a/lib/lurch/inflector.rb
+++ b/lib/lurch/inflector.rb
@@ -5,7 +5,9 @@ require "dry/inflector"
 module Lurch
   class Inflector
     def initialize(inflection_mode, types_mode)
-      @inflector = Dry::Inflector.new
+      @inflector = Dry::Inflector.new do |inflections|
+        inflections.plural "people", "people"
+      end
       define_encode_key(inflection_mode)
       define_encode_type(types_mode)
     end

--- a/lib/lurch/inflector.rb
+++ b/lib/lurch/inflector.rb
@@ -5,10 +5,6 @@ module Lurch
       define_encode_type(types_mode)
     end
 
-    def self.classify(str)
-      Inflecto.classify(str)
-    end
-
     def self.decode_key(key)
       Inflecto.underscore(key.to_s).to_sym
     end

--- a/lib/lurch/inflector.rb
+++ b/lib/lurch/inflector.rb
@@ -5,11 +5,11 @@ module Lurch
       define_encode_type(types_mode)
     end
 
-    def self.decode_key(key)
+    def decode_key(key)
       Inflecto.underscore(key.to_s).to_sym
     end
 
-    def self.decode_type(type)
+    def decode_type(type)
       Inflecto.pluralize(decode_key(type)).to_sym
     end
 

--- a/lib/lurch/query.rb
+++ b/lib/lurch/query.rb
@@ -37,7 +37,7 @@ module Lurch
     end
 
     def type(type)
-      @type = Inflector.decode_type(type)
+      @type = inflector.decode_type(type)
       self
     end
 
@@ -60,14 +60,14 @@ module Lurch
 
     def save(changeset)
       raise ArgumentError, "No type specified for query" if @type.nil?
-      raise ArgumentError, "Type mismatch" if @type != Inflector.decode_type(changeset.type)
+      raise ArgumentError, "Type mismatch" if @type != inflector.decode_type(changeset.type)
 
       @store.save(changeset, to_query)
     end
 
     def insert(changeset)
       raise ArgumentError, "No type specified for query" if @type.nil?
-      raise ArgumentError, "Type mismatch" if @type != Inflector.decode_type(changeset.type)
+      raise ArgumentError, "Type mismatch" if @type != inflector.decode_type(changeset.type)
 
       @store.insert(changeset, to_query)
     end
@@ -87,8 +87,10 @@ module Lurch
 
   private
 
+    attr_reader :inflector
+
     def uri_builder
-      @uri_builder ||= URIBuilder.new(@inflector)
+      @uri_builder ||= URIBuilder.new(inflector)
     end
 
     def to_query
@@ -109,16 +111,16 @@ module Lurch
     end
 
     def filter_query
-      @inflector.encode_keys(@filter)
+      inflector.encode_keys(@filter)
     end
 
     def include_query
-      @include.map { |path| @inflector.encode_key(path) }.compact.uniq.join(",")
+      @include.map { |path| inflector.encode_key(path) }.compact.uniq.join(",")
     end
 
     def fields_query
-      @inflector.encode_types(@fields) do |fields|
-        fields.map { |field| @inflector.encode_key(field) }.compact.uniq.join(",")
+      inflector.encode_types(@fields) do |fields|
+        fields.map { |field| inflector.encode_key(field) }.compact.uniq.join(",")
       end
     end
 
@@ -127,7 +129,7 @@ module Lurch
     end
 
     def sort_key(key, direction)
-      encoded_key = @inflector.encode_key(key)
+      encoded_key = inflector.encode_key(key)
       case direction
       when :asc
         encoded_key

--- a/lib/lurch/query.rb
+++ b/lib/lurch/query.rb
@@ -60,13 +60,15 @@ module Lurch
 
     def save(changeset)
       raise ArgumentError, "No type specified for query" if @type.nil?
-      raise ArgumentError, "Type mismatch" if @type != changeset.type
+      raise ArgumentError, "Type mismatch" if @type != Inflector.decode_type(changeset.type)
+
       @store.save(changeset, to_query)
     end
 
     def insert(changeset)
       raise ArgumentError, "No type specified for query" if @type.nil?
-      raise ArgumentError, "Type mismatch" if @type != changeset.type
+      raise ArgumentError, "Type mismatch" if @type != Inflector.decode_type(changeset.type)
+
       @store.insert(changeset, to_query)
     end
 

--- a/lib/lurch/query.rb
+++ b/lib/lurch/query.rb
@@ -79,7 +79,7 @@ module Lurch
     end
 
     def inspect
-      type = @type.nil? ? "" : "[#{Inflector.classify(@type)}]"
+      type = @type.nil? ? "" : "[#{@type}]"
       query = to_query
       query = query.empty? ? "" : " #{query.inspect}"
       "#<#{self.class}#{type}#{query}>"

--- a/lib/lurch/relationship.rb
+++ b/lib/lurch/relationship.rb
@@ -13,6 +13,10 @@ module Lurch
       !!defined?(@data)
     end
 
+    def inflector
+      @store.inflector
+    end
+
     def respond_to_missing?(method, all)
       raise Errors::RelationshipNotLoaded, @relationship_key unless loaded?
       super

--- a/lib/lurch/relationship/has_many.rb
+++ b/lib/lurch/relationship/has_many.rb
@@ -9,7 +9,7 @@ module Lurch
       end
 
       def inspect
-        suffix = @data.first ? "[#{Inflector.classify(@data.first.type)}]" : ""
+        suffix = @data.first ? "[#{@data.first.type}]" : ""
         "#<#{self.class}#{suffix} size: #{@data.size}>"
       end
     end

--- a/lib/lurch/relationship/has_one.rb
+++ b/lib/lurch/relationship/has_one.rb
@@ -14,7 +14,7 @@ module Lurch
       end
 
       def inspect
-        @data.nil? ? "#<#{self.class} nil>" : "#<#{self.class}[#{Inflector.classify(@type)}] id: #{@id.inspect}>"
+        @data.nil? ? "#<#{self.class} nil>" : "#<#{self.class}[#{@type}] id: #{@id.inspect}>"
       end
     end
   end

--- a/lib/lurch/relationship/has_one.rb
+++ b/lib/lurch/relationship/has_one.rb
@@ -7,7 +7,7 @@ module Lurch
         if document["data"].nil?
           @data = nil
         else
-          @type = Inflector.decode_type(document["data"]["type"])
+          @type = inflector.decode_type(document["data"]["type"])
           @id = document["data"]["id"]
           @data = Resource.new(@store, @type, @id)
         end

--- a/lib/lurch/resource.rb
+++ b/lib/lurch/resource.rb
@@ -4,7 +4,7 @@ module Lurch
 
     def initialize(store, type, id)
       @store = store
-      @type = Inflector.decode_type(type)
+      @type = @store.inflector.decode_type(type)
       @id = id
     end
 

--- a/lib/lurch/resource.rb
+++ b/lib/lurch/resource.rb
@@ -18,13 +18,13 @@ module Lurch
     end
 
     def attributes
-      raise Errors::ResourceNotLoaded, resource_class_name unless loaded?
+      raise Errors::ResourceNotLoaded, type unless loaded?
 
       resource_from_store.attributes
     end
 
     def relationships
-      raise Errors::ResourceNotLoaded, resource_class_name unless loaded?
+      raise Errors::ResourceNotLoaded, type unless loaded?
 
       resource_from_store.relationships
     end
@@ -38,13 +38,9 @@ module Lurch
     end
 
     def [](attribute)
-      raise Errors::ResourceNotLoaded, resource_class_name unless loaded?
+      raise Errors::ResourceNotLoaded, type unless loaded?
 
       resource_from_store.attribute(attribute)
-    end
-
-    def resource_class_name
-      Inflector.classify(type)
     end
 
     def inspect
@@ -68,7 +64,7 @@ module Lurch
     end
 
     def method_missing(method, *arguments, &block)
-      raise Errors::ResourceNotLoaded, resource_class_name unless loaded?
+      raise Errors::ResourceNotLoaded, type unless loaded?
 
       return resource_from_store.attribute(method) if resource_from_store.attribute?(method)
       if resource_from_store.relationship?(method)

--- a/lib/lurch/resource.rb
+++ b/lib/lurch/resource.rb
@@ -53,7 +53,7 @@ module Lurch
                    else
                      "not loaded"
                    end
-      "#<#{self.class}[#{resource_class_name}] id: #{id.inspect}, #{inspection}>"
+      "#<#{self.class}[#{type}] id: #{id.inspect}, #{inspection}>"
     end
 
   private

--- a/lib/lurch/store.rb
+++ b/lib/lurch/store.rb
@@ -19,7 +19,9 @@ module Lurch
 
     def save(changeset, query = {})
       return insert(changeset) if changeset.id.nil?
-      url = uri_builder.resource_uri(changeset.type, changeset.id, query)
+
+      type = Inflector.decode_type(changeset.type)
+      url = uri_builder.resource_uri(type, changeset.id, query)
 
       document = @client.patch(url, payload_builder.build(changeset))
       process_document(document)
@@ -30,7 +32,9 @@ module Lurch
 
     def insert(changeset, query = {})
       return save(changeset) unless changeset.id.nil?
-      url = uri_builder.resources_uri(changeset.type, query)
+
+      type = Inflector.decode_type(changeset.type)
+      url = uri_builder.resources_uri(type, query)
 
       document = @client.post(url, payload_builder.build(changeset))
       process_document(document)

--- a/lib/lurch/store.rb
+++ b/lib/lurch/store.rb
@@ -17,11 +17,13 @@ module Lurch
       Resource.new(self, stored_resource.type, stored_resource.id)
     end
 
-    def save(changeset, query = {})
+    def save(changeset, query = {}) # rubocop:disable Metrics/AbcSize
       return insert(changeset) if changeset.id.nil?
 
-      type = Inflector.decode_type(changeset.type)
-      url = uri_builder.resource_uri(type, changeset.id, query)
+      url = uri_builder.resource_uri(
+        inflector.decode_type(changeset.type),
+        changeset.id, query
+      )
 
       document = @client.patch(url, payload_builder.build(changeset))
       process_document(document)
@@ -33,7 +35,7 @@ module Lurch
     def insert(changeset, query = {})
       return save(changeset) unless changeset.id.nil?
 
-      type = Inflector.decode_type(changeset.type)
+      type = inflector.decode_type(changeset.type)
       url = uri_builder.resources_uri(type, query)
 
       document = @client.post(url, payload_builder.build(changeset))
@@ -74,7 +76,7 @@ module Lurch
 
     # @private
     def resource_from_store(type, id)
-      normalized_type = Inflector.decode_type(type)
+      normalized_type = inflector.decode_type(type)
       @store[normalized_type][id]
     end
 
@@ -83,11 +85,14 @@ module Lurch
       Query.new(self, inflector)
     end
 
-  private
-
+    # @private
     def inflector
       @inflector ||= Inflector.new(@config.inflection_mode, @config.types_mode)
     end
+
+  private
+
+    def changeset_type(changeset); end
 
     def uri_builder
       @uri_builder ||= URIBuilder.new(inflector)

--- a/lib/lurch/stored_resource.rb
+++ b/lib/lurch/stored_resource.rb
@@ -10,7 +10,7 @@ module Lurch
     end
 
     def type
-      @type ||= Inflector.decode_type(@resource_object["type"])
+      @type ||= inflector.decode_type(@resource_object["type"])
     end
 
     def attributes
@@ -39,15 +39,19 @@ module Lurch
 
   private
 
+    def inflector
+      @store.inflector
+    end
+
     def fixed_attributes
       @fixed_attributes ||= resource_attributes.each_with_object({}) do |(key, value), hash|
-        hash[Inflector.decode_key(key)] = value
+        hash[inflector.decode_key(key)] = value
       end
     end
 
     def fixed_relationships
       @fixed_relationships ||= resource_relationships.each_with_object({}) do |(key, value), hash|
-        relationship_key = Inflector.decode_key(key)
+        relationship_key = inflector.decode_key(key)
         hash[relationship_key] = Relationship.from_document(@store, relationship_key, value)
       end
     end

--- a/lurch.gemspec
+++ b/lurch.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($RS)
   gem.require_paths = ["lib"]
 
+  gem.add_dependency("dry-inflector", "< 1.0")
   gem.add_dependency("faraday", "< 1.0")
-  gem.add_dependency("inflecto", "~> 0.0")
   gem.add_dependency("rack", ">= 1.0")
   gem.add_dependency("typhoeus", "< 2.0")
 

--- a/test/lurch/test_fetch_resources.rb
+++ b/test/lurch/test_fetch_resources.rb
@@ -65,7 +65,7 @@ class TestFetchResources < Minitest::Test
     refute phone_number.loaded?
     assert phone_number.inspect
     err = assert_raises(Lurch::Errors::ResourceNotLoaded) { phone_number.name }
-    assert_equal "Resource (PhoneNumber) not loaded, try calling #fetch first.", err.message
+    assert_equal "Resource (phone_numbers) not loaded, try calling #fetch first.", err.message
 
     stub_get("#{phone_number_type}/1", @response_factory.phone_number_response("1", "Cell", "111-222-3344"))
 


### PR DESCRIPTION
This was done in two steps:
1. Removing the class methods from Inflector
2. Replacing dry-inflector instead of Inflecto

1 is good, because that way we can have different inflector settings per Store. 🤷‍♂️ 